### PR TITLE
Add a deploy step in the pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -96,30 +96,30 @@ spec:
       steps {
         container('dev') {
           sh '''
-              export GIT_COMMIT_REV=$(git log -n 1 --pretty=format:'%h')
-              export GIT_SCM_URL=$(git remote show origin | grep 'Fetch URL' | awk '{print $3}')
-              export SCM_URI=$(echo $GIT_SCM_URL | awk '{print gensub("git@github.com:","https://github.com/",$3)}')
+            export GIT_COMMIT_REV=$(git log -n 1 --pretty=format:'%h')
+            export GIT_SCM_URL=$(git remote show origin | grep 'Fetch URL' | awk '{print $3}')
+            export SCM_URI=$(echo $GIT_SCM_URL | awk '{print gensub("git@github.com:","https://github.com/",$3)}')
 
-              img build \
-                  -t $IMAGE_NAME \
-                  --build-arg "GIT_COMMIT_REV=$GIT_COMMIT_REV" \
-                  --build-arg "GIT_SCM_URL=$GIT_SCM_URL" \
-                  --build-arg "BUILD_DATE=$BUILD_DATE" \
-                  --label "org.opencontainers.image.source=$GIT_SCM_URL" \
-                  --label "org.label-schema.vcs-url=$GIT_SCM_URL" \
-                  --label "org.opencontainers.image.url=$SCM_URI" \
-                  --label "org.label-schema.url=$SCM_URI" \
-                  --label "org.opencontainers.image.revision=$GIT_COMMIT_REV" \
-                  --label "org.label-schema.vcs-ref=$GIT_COMMIT_REV" \
-                  --label "org.opencontainers.image.created=$BUILD_DATE" \
-                  --label "org.label-schema.build-date=$BUILD_DATE" \
-                  -f $DOCKERFILE \
-                  -o type=docker,dest=image.tar \
-                  .
+            img build \
+              -t $IMAGE_NAME \
+              --build-arg "GIT_COMMIT_REV=$GIT_COMMIT_REV" \
+              --build-arg "GIT_SCM_URL=$GIT_SCM_URL" \
+              --build-arg "BUILD_DATE=$BUILD_DATE" \
+              --label "org.opencontainers.image.source=$GIT_SCM_URL" \
+              --label "org.label-schema.vcs-url=$GIT_SCM_URL" \
+              --label "org.opencontainers.image.url=$SCM_URI" \
+              --label "org.label-schema.url=$SCM_URI" \
+              --label "org.opencontainers.image.revision=$GIT_COMMIT_REV" \
+              --label "org.label-schema.vcs-ref=$GIT_COMMIT_REV" \
+              --label "org.opencontainers.image.created=$BUILD_DATE" \
+              --label "org.label-schema.build-date=$BUILD_DATE" \
+              -f $DOCKERFILE \
+              -o type=docker,dest=image.tar \
+              .
           '''
         }
       }
-    }
+    } // stage
     stage("Test") {
       steps {
         container('dev') {
@@ -128,6 +128,45 @@ spec:
           '''
         }
       }
-    }
-  }
+    } // stage
+    stage("Deploy latest") {
+      when { branch "${config.mainBranch}" }
+      steps {
+        container('dev') {
+          script {
+            sh "img tag ${config.registry}${imageName} ${config.registry}${imageName}:${config.mainBranch}"
+            withCredentials([usernamePassword(credentialsId: config.credentials, usernameVariable: 'DOCKER_USR', passwordVariable: 'DOCKER_PSW')]) {
+              sh "echo $DOCKER_PSW | img login -u $DOCKER_USR --password-stdin"
+            }
+            sh "img push ${config.registry}${imageName}:${config.mainBranch}"
+            sh "img push ${config.registry}${imageName}"
+            sh "img logout"
+            if (currentBuild.description) {
+              currentBuild.description = currentBuild.description + " / "
+            }
+            currentBuild.description = "${config.mainBranch} / ${GIT_COMMIT}"
+          }
+        }
+      }
+    } // stage
+    stage("Deploy tag as tag") {
+      when { buildingTag() }
+      steps {
+        container('dev') {
+          script {
+            sh "img tag ${config.registry}${imageName} ${config.registry}${imageName}:${TAG_NAME}"
+            withCredentials([usernamePassword(credentialsId: config.credentials, usernameVariable: 'DOCKER_USR', passwordVariable: 'DOCKER_PSW')]) {
+              sh "echo $DOCKER_PSW | img login -u $DOCKER_USR --password-stdin"
+            }
+            sh "img push ${config.registry}${imageName}:${TAG_NAME}"
+            sh "img logout"
+            if (currentBuild.description) {
+              currentBuild.description = currentBuild.description + " / "
+            }
+            currentBuild.description = "${TAG_NAME}"
+          }
+        }
+      }
+    } // stage
+  } // stages
 }


### PR DESCRIPTION
This PR is blocked by #4.

It introduces a "deploy step" to push the image when a build is triggered on the main branch (Continuous Deployment for `latest` Docker tag) or on tags (Continuous Delivery with a Docker tag equals to the git tag)