### PR TITLE
Introduces a `Makefile`-based build flow

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -89,6 +89,7 @@ spec:
     buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5'))
     timeout(time: 60, unit: "MINUTES")
     ansiColor("xterm")
+    preserveStashes()
   }
 
   stages {
@@ -98,47 +99,26 @@ spec:
           withCredentials([usernamePassword(credentialsId: config.credentials, usernameVariable: 'DOCKER_USR', passwordVariable: 'DOCKER_PSW')]) {
             sh "echo $DOCKER_PSW | img login -u $DOCKER_USR --password-stdin"
           }
-          sh '''
-            export GIT_COMMIT_REV=$(git log -n 1 --pretty=format:'%h')
-            export GIT_SCM_URL=$(git remote show origin | grep 'Fetch URL' | awk '{print $3}')
-            export SCM_URI=$(echo $GIT_SCM_URL | awk '{print gensub("git@github.com:","https://github.com/",$3)}')
-
-            img build \
-              -t $IMAGE_NAME \
-              --build-arg "GIT_COMMIT_REV=$GIT_COMMIT_REV" \
-              --build-arg "GIT_SCM_URL=$GIT_SCM_URL" \
-              --build-arg "BUILD_DATE=$BUILD_DATE" \
-              --label "org.opencontainers.image.source=$GIT_SCM_URL" \
-              --label "org.label-schema.vcs-url=$GIT_SCM_URL" \
-              --label "org.opencontainers.image.url=$SCM_URI" \
-              --label "org.label-schema.url=$SCM_URI" \
-              --label "org.opencontainers.image.revision=$GIT_COMMIT_REV" \
-              --label "org.label-schema.vcs-ref=$GIT_COMMIT_REV" \
-              --label "org.opencontainers.image.created=$BUILD_DATE" \
-              --label "org.label-schema.build-date=$BUILD_DATE" \
-              -f $DOCKERFILE \
-              .
-          '''
-          sh 'img save --output=./image.tar $IMAGE_NAME'
-        } // container
-      } // steps
+          sh 'make build'
+          sh 'make image.tar'
+          stash name: 'image', includes: 'image.tar'
+        }
+      }
     } // stage
     stage("Test") {
       steps {
         container('dev') {
-          sh '''
-          container-structure-test test --driver tar --image image.tar --config ./cst.yml
-          '''
-        } // container
-      } // steps
+          unstash 'image'
+          sh 'make test'
+        }
+      }
     } // stage
     stage("Deploy latest") {
       when { branch "${config.mainBranch}" }
       steps {
         container('dev') {
-          sh "img tag ${config.registry}${imageName} ${config.registry}${imageName}:${config.mainBranch}"
-          sh "img push ${config.registry}${imageName}:${config.mainBranch}"
-          sh "img push ${config.registry}${imageName}"
+          sh "IMAGE_DEPLOY=${IMAGE_NAME}:${config.mainBranch} make deploy"
+          sh "IMAGE_DEPLOY=${IMAGE_NAME}:latest make deploy"
           script {
             if (currentBuild.description) {
               currentBuild.description = currentBuild.description + " / "
@@ -152,8 +132,7 @@ spec:
       when { buildingTag() }
       steps {
         container('dev') {
-          sh "img tag ${config.registry}${imageName} ${config.registry}${imageName}:${TAG_NAME}"
-          sh "img push ${config.registry}${imageName}:${TAG_NAME}"
+          sh "IMAGE_DEPLOY=${IMAGE_NAME}:${TAG_NAME} make deploy"
           script {
             if (currentBuild.description) {
               currentBuild.description = currentBuild.description + " / "

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+
+IMAGE_NAME ?= docker-builder
+IMAGE_DEPLOY ?= $(IMAGE_NAME)
+DOCKERFILE ?= Dockerfile
+
+GIT_COMMIT_REV ?= $(shell git log -n 1 --pretty=format:'%h')
+GIT_SCM_URL ?= $(shell git config --get remote.origin.url)
+SCM_URI ?= $(subst git@github.com:,https://github.com/,$(GIT_SCM_URL))
+BUILD_DATE ?= $(shell date --utc '+%Y-%m-%dT%H:%M:%S')
+
+export GIT_COMMIT_REV GIT_SCM_URL SCM_URI
+
+help: ## Show this Makefile's help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+build: ## Build the Docker Image to the local img's cache
+	img build \
+		-t $(IMAGE_NAME) \
+		--build-arg "GIT_COMMIT_REV=$(GIT_COMMIT_REV)" \
+		--build-arg "GIT_SCM_URL=$(GIT_SCM_URL)" \
+		--build-arg "BUILD_DATE=$(BUILD_DATE)" \
+		--label "org.opencontainers.image.source=$(GIT_SCM_URL)" \
+		--label "org.label-schema.vcs-url=$(GIT_SCM_URL)" \
+		--label "org.opencontainers.image.url=$(SCM_URI)" \
+		--label "org.label-schema.url=$(SCM_URI)" \
+		--label "org.opencontainers.image.revision=$(GIT_COMMIT_REV)" \
+		--label "org.label-schema.vcs-ref=$(GIT_COMMIT_REV)" \
+		--label "org.opencontainers.image.created=$(BUILD_DATE)" \
+		--label "org.label-schema.build-date=$(BUILD_DATE)" \
+		-f $(DOCKERFILE) \
+		./
+
+image.tar: build ## Export the built Docker Image as the 'image.tar' archive.
+	img save --output=./image.tar $(IMAGE_NAME)
+
+clean: ## Delete any file generated during the build steps
+	rm -f ./image.tar
+
+test: image.tar ## Execute the test harness on the 'image.tar' Docker Image.
+	container-structure-test test --driver=tar --image=image.tar --config=./cst.yml
+
+## This steps expects that you are logged to the Docker registry to push image into
+deploy: ## Tag and push the built image as specified by $(IMAGE_DEPLOY).
+	img tag $(IMAGE_NAME) $(IMAGE_DEPLOY)
+	img push $(IMAGE_DEPLOY)
+
+.PHONY: all clean build test deploy

--- a/README.adoc
+++ b/README.adoc
@@ -1,19 +1,49 @@
 = Docker Image for Building Docker Images
 
-image::https://i.imgur.com/d7KZNKD.png[Inception,width=400]
+image::https://i.imgur.com/d7KZNKD.png[Inception,width=200]
 
 This repository hosts the resources to build a Docker Image
 used for... building Docker Images.
 
 Its target is to allow building https://github.com/opencontainers/image-spec[OCI compliant images] in rootless or daemonless contexts as Kubernetes non privileged pods.
 
+image::https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggTFJcbiAgICBBW0RvY2tlcmZpbGVdIC0tPnxtYWtlIGxpbnR8IEIoRG9ja2VyZmlsZSlcbiAgICBCIC0tPiB8bWFrZSBidWlsZHwgQ1tpbWFnZS50YXJdXG4gICAgQyAtLT4gfG1ha2UgdGVzdHwgRChpbWFnZS50YXIpXG4gICAgRCAtLT4gfG1ha2UgZGVwbG95fCBFKHJlZ2lzdHJ5LmRvY2tlci9pbWFnZTp0YWcpXG4gICAgRSAtLT4gfG1ha2UgcmVsZWFzZXwgRihyZWdpc3RyeS5kb2NrZXIvaW1hZ2U6bGF0ZXN0KVxuICBcbiAgICAgICAgICAgICIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9[link="https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggTFJcbiAgICBBW0RvY2tlcmZpbGVdIC0tPnxtYWtlIGxpbnR8IEIoRG9ja2VyZmlsZSlcbiAgICBCIC0tPiB8bWFrZSBidWlsZHwgQ1tpbWFnZS50YXJdXG4gICAgQyAtLT4gfG1ha2UgdGVzdHwgRChpbWFnZS50YXIpXG4gICAgRCAtLT4gfG1ha2UgZGVwbG95fCBFKHJlZ2lzdHJ5LmRvY2tlci9pbWFnZTp0YWcpXG4gICAgRSAtLT4gfG1ha2UgcmVsZWFzZXwgRihyZWdpc3RyeS5kb2NrZXIvaW1hZ2U6bGF0ZXN0KVxuICBcbiAgICAgICAgICAgICIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9","Click on the Build Flow diagram to edit"]
+
+== Requirements
+
+=== Bare Requirements
+
+* Command prompt with bash (or zsh/ksh)
+* GNU Make 3.81+
+* [Build,Deploy,Deploy] (Jessie Frazelle's) https://github.com/genuinetools/img[`genuinetools/img`] CLI in v0.5.11
+* [Test] https://github.com/GoogleContainerTools/container-structure-test[Google Container Test] CLI in v1.9.1
+
+If you cannot fulfil these requirements, please check the <<Using Docker>> section instead.
+
+=== Using Docker
+
+If you prefer to run all the below commands in a Docker image instead of the <<Bare Requirements>> (or if you cannot meet the bare-requirements):
+
+[source,bash]
+----
+docker run --rm --tty --interactive --volume=$(pwd):/app --workdir=/app --entrypoint=bash \
+  --security-opt seccomp=unconfined --security-opt apparmor=unconfined \
+  jenkinsciinfra/builder:latest
+> make help
+----
+
 == Build Image
 
-Build the docker image with `docker build -t <name> ./`.
+With the <<Requirements>> installed for the Build phase, you can build the image with the command `make build`.
 
 == Test Image
 
-Test the docker image with https://github.com/GoogleContainerTools/container-structure-test[Google Container Test] installed:
+With the <<Requirements>> installed for the Test phase, you can build the image with the command `make test`.
 
-[source,bash]
-container-structure-test test --driver tar --image <name> --config ./cst.yml
+== Deploy Image
+
+With the <<Requirements>> installed for the Deploy phase, you can build the image:
+
+- First by logging in to the Docker registry where you want to deploy the image to,
+with the command `img login <Registry's URL if it is not the DockerHub>`
+- Running the command `make deploy`


### PR DESCRIPTION
This PR features a `Makefile` to execute the main steps of the build process, to ensure that the pipeline code stays as minimalist as possible (only credentials and Jenkins specifics).

It allows a reproducible way to build, test and deploy the image if you have the needed requirements on your machine.

Checklist before review:

- [x] Add build step to the Makefile
- [x] Add test step to the Makefile
- [x] Add deploy step to the Makefile (after #5 is merged and the main branch is successfully deploying)
- [x] Update README to explain the Make targets
- [x] Apply @rtyler 's (❤️ ) "self documented" Makefile technique from https://brokenco.de/2019/04/22/self-describing-make.html 