### PR TITLE
Feat: Bump CST version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,17 +17,17 @@ RUN apk add --no-cache \
   pigz=~2.4
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-# No checksum provided so no verification (yet?)
 ARG CST_VERSION=1.10.0
 RUN curl --silent --show-error --location --output /usr/local/bin/container-structure-test \
    "https://storage.googleapis.com/container-structure-test/v${CST_VERSION}/container-structure-test-linux-amd64" \
+  && sha256sum /usr/local/bin/container-structure-test | grep -q 72deeea26c990274725a325cf14acd20b8404251c4fcfc4d34b7527aac6c28bc \
   && chmod a+x /usr/local/bin/container-structure-test \
   && container-structure-test version
 
-# No checksum provided so no verification (yet?)
 ARG HADOLINT_VERSION=1.19.0
 RUN curl --silent --show-error --location --output /usr/local/bin/hadolint \
    "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
+  && sha256sum /usr/local/bin/hadolint | grep -q 5099a932032f0d2c708529fb7739d4b2335d0e104ed051591a41d622fe4e4cc4 \
   && chmod a+x /usr/local/bin/hadolint \
   && hadolint -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,9 @@ RUN apk add --no-cache \
   # Required for img's builds
   pigz=~2.4
 
-### Install Google's container-structure-test CLI
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # No checksum provided so no verification (yet?)
-ARG CST_VERSION=1.9.1
+ARG CST_VERSION=1.10.0
 RUN curl --silent --show-error --location --output /usr/local/bin/container-structure-test \
    "https://storage.googleapis.com/container-structure-test/v${CST_VERSION}/container-structure-test-linux-amd64" \
   && chmod a+x /usr/local/bin/container-structure-test \

--- a/cst.yml
+++ b/cst.yml
@@ -15,7 +15,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.hadolint.version
       value: "1.19.0"
     - key: io.jenkins-infra.tools.container-structure-test.version
-      value: "1.9.1"
+      value: "1.10.0"
     - key: io.jenkins-infra.tools.img.version
       value: "0.5.11"
   entrypoint: []
@@ -65,4 +65,3 @@ fileContentTests:
   - name: 'subgid contains user 65,536 subordinate GIDs'
     path: '/etc/subgid'
     expectedContents: ['.*user:100000:65536.*']
-  


### PR DESCRIPTION
This PR introduces the following changes:

- Bump CST to 1.10.0 (to allow exporting results to Junit format - https://github.com/GoogleContainerTools/container-structure-test/releases/tag/v1.10.0
- Verify the checksum of the downloaded binaries for `hadolint` and cst