### PR TITLE
Image improvements from docker-terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ LABEL io.jenkins-infra.tools.hadolint.version="${HADOLINT_VERSION}"
 ARG UID=1000
 ENV USER=infra
 ENV HOME=/home/"${USER}"
-ENV XDG_RUNTIME_DIR=/run/user/1000
+ENV XDG_RUNTIME_DIR=/run/${USER}/1000
 
 RUN adduser -D -u "${UID}" "${USER}" \
   && mkdir -p "${XDG_RUNTIME_DIR}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG IMG_VERSION=0.5.11
 FROM r.j3ss.co/img:v${IMG_VERSION} AS img
 
 # Alpine is used by default for fast and ligthweight customization with a fixed minor to benefit of the latest patches
-FROM alpine:3.12
+FROM alpine:3.13
 ## Repeating the ARG to add it into the scope of this image
 ARG IMG_VERSION
 RUN apk add --no-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-# We need the official img image to retrieve the img and new*idmap binaries
+# The official img's image is required to retrieve the img and new*idmap binaries
 ARG IMG_VERSION=0.5.11
 FROM r.j3ss.co/img:v${IMG_VERSION} AS img
 
 # Alpine is used by default for fast and ligthweight customization with a fixed minor to benefit of the latest patches
 FROM alpine:3.12
-ARG IMG_VERSION=0.5.11
+## Repeating the ARG to add it into the scope of this image
+ARG IMG_VERSION
 RUN apk add --no-cache \
   # Recommended (even though not strictly required) for jenkins agents
   bash=~5 \
@@ -16,7 +17,9 @@ RUN apk add --no-cache \
   # Required for img's builds
   pigz=~2.4
 
+## bash need to be installed for this instruction to work as expected
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ARG CST_VERSION=1.10.0
 RUN curl --silent --show-error --location --output /usr/local/bin/container-structure-test \
    "https://storage.googleapis.com/container-structure-test/v${CST_VERSION}/container-structure-test-linux-amd64" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,18 @@ RUN apk add --no-cache \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG CST_VERSION=1.10.0
+ARG CST_SHASUM_256="72deeea26c990274725a325cf14acd20b8404251c4fcfc4d34b7527aac6c28bc"
 RUN curl --silent --show-error --location --output /usr/local/bin/container-structure-test \
    "https://storage.googleapis.com/container-structure-test/v${CST_VERSION}/container-structure-test-linux-amd64" \
-  && sha256sum /usr/local/bin/container-structure-test | grep -q 72deeea26c990274725a325cf14acd20b8404251c4fcfc4d34b7527aac6c28bc \
+  && sha256sum /usr/local/bin/container-structure-test | grep -q "${CST_SHASUM_256}" \
   && chmod a+x /usr/local/bin/container-structure-test \
   && container-structure-test version
 
 ARG HADOLINT_VERSION=1.19.0
+ARG HADOLINT_SHASUM_256="5099a932032f0d2c708529fb7739d4b2335d0e104ed051591a41d622fe4e4cc4"
 RUN curl --silent --show-error --location --output /usr/local/bin/hadolint \
    "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64" \
-  && sha256sum /usr/local/bin/hadolint | grep -q 5099a932032f0d2c708529fb7739d4b2335d0e104ed051591a41d622fe4e4cc4 \
+  && sha256sum /usr/local/bin/hadolint | grep -q "${HADOLINT_SHASUM_256}" \
   && chmod a+x /usr/local/bin/hadolint \
   && hadolint -v
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,19 +41,21 @@ LABEL io.jenkins-infra.tools.container-structure-test.version="${CST_VERSION}"
 LABEL io.jenkins-infra.tools.img.version="${IMG_VERSION}"
 LABEL io.jenkins-infra.tools.hadolint.version="${HADOLINT_VERSION}"
 
-RUN adduser -D -u 1000 user \
-  && mkdir -p /run/user/1000 \
-  && chown -R user /run/user/1000 /home/user \
-  && echo user:100000:65536 | tee /etc/subuid | tee /etc/subgid
+ARG UID=1000
+ENV USER=infra
+ENV HOME=/home/"${USER}"
+ENV XDG_RUNTIME_DIR=/run/user/1000
+
+RUN adduser -D -u "${UID}" "${USER}" \
+  && mkdir -p "${XDG_RUNTIME_DIR}" \
+  && chown -R "${USER}" "${XDG_RUNTIME_DIR}" "${HOME}" \
+  && echo "${USER}":100000:65536 | tee /etc/subuid | tee /etc/subgid
 
 COPY --from=img /usr/bin/img /usr/bin/img
 COPY --from=img /usr/bin/newuidmap /usr/bin/newuidmap
 COPY --from=img /usr/bin/newgidmap /usr/bin/newgidmap
 
-USER user
-ENV USER=user
-ENV HOME=/home/user
-ENV XDG_RUNTIME_DIR=/run/user/1000
+USER "${USER}"
 
 CMD ["/bin/bash"]
 WORKDIR "/app"

--- a/cst.yml
+++ b/cst.yml
@@ -23,25 +23,46 @@ metadataTest:
   workdir: "/app"
 
 fileExistenceTests:
-
   - name: 'Google Container Test CLI'
     path: '/usr/local/bin/container-structure-test'
     shouldExist: true
+    isExecutableBy: 'any'
   - name: 'HADOLINT'
     path: '/usr/local/bin/hadolint'
     shouldExist: true
-  - name: 'Root'
-    path: '/'
-    shouldExist: true
+    isExecutableBy: 'any'
   - name: 'img'
     path: '/usr/bin/img'
     shouldExist: true
+    isExecutableBy: 'any'
   - name: 'img newuidmap'
     path: '/usr/bin/newuidmap'
     shouldExist: true
+    isExecutableBy: 'any'
   - name: 'img newgidmap'
     path: '/usr/bin/newgidmap'
     shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'Bash'
+    path: '/bin/bash'
+    shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'Curl'
+    path: '/usr/bin/curl'
+    shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'Make'
+    path: '/usr/bin/make'
+    shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'Git'
+    path: '/usr/bin/git'
+    shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'Git'
+    path: '/usr/bin/pigz'
+    shouldExist: true
+    isExecutableBy: 'any'
   - name: 'subuid'
     path: '/etc/subuid'
     shouldExist: true

--- a/cst.yml
+++ b/cst.yml
@@ -4,11 +4,11 @@ schemaVersion: 2.0.0
 metadataTest:
   env:
     - key: "USER"
-      value: "user"
+      value: "infra"
     - key: "HOME"
-      value: "/home/user"
+      value: "/home/infra"
     - key: "XDG_RUNTIME_DIR"
-      value: "/run/user/1000"
+      value: "/run/infra/1000"
   labels:
     - key: io.jenkins-infra.tools
       value: "img,container-structure-test,git,make,hadolint"
@@ -69,23 +69,23 @@ fileExistenceTests:
   - name: 'subgid'
     path: '/etc/subgid'
     shouldExist: true
-  - name: 'user directory'
-    path: '/run/user/1000'
+  - name: 'temp directory for user infra'
+    path: '/run/infra/1000'
     shouldExist: true
-  - name: 'home user'
-    path: '/home/user'
+  - name: 'homedir of the user infra'
+    path: '/home/infra'
     shouldExist: true
 
 fileContentTests:
-  - name: 'image user created as non-root user'
+  - name: 'user infra exists'
     path: '/etc/passwd'
-    expectedContents: ['.*user:x:1000:1000.*']
-  - name: 'subuid contains user with 65,536 subordinate UIDs'
+    expectedContents: ['.*infra:x:1000:1000.*']
+  - name: 'subuid contains user infra with expected subordinate UIDs/GIDs'
     path: '/etc/subuid'
-    expectedContents: ['.*user:100000:65536.*']
-  - name: 'subgid contains user 65,536 subordinate GIDs'
+    expectedContents: ['.*infra:100000:65536.*']
+  - name: 'subgid contains user infra with expected subordinate UIDs/GIDs'
     path: '/etc/subgid'
-    expectedContents: ['.*user:100000:65536.*']
+    expectedContents: ['.*infra:100000:65536.*']
   - name: 'Base OS is the expected distribution and versions'
     path: '/etc/os-release'
     expectedContents: ['PRETTY_NAME="Alpine Linux v3.13"']

--- a/cst.yml
+++ b/cst.yml
@@ -86,3 +86,6 @@ fileContentTests:
   - name: 'subgid contains user 65,536 subordinate GIDs'
     path: '/etc/subgid'
     expectedContents: ['.*user:100000:65536.*']
+  - name: 'Base OS is the expected distribution and versions'
+    path: '/etc/os-release'
+    expectedContents: ['PRETTY_NAME="Alpine Linux v3.13"']


### PR DESCRIPTION
This PR introduces a set of changes inspired from the https://github.com/jenkins-infra/docker-terraform/pull/3 .

- (non functional) The shasum of the downloaded binaries are provided as Dockerfile's `ARG` instruction to provide customization in the future
- (non functional) Avoid repetition of the default value of the ARG `IMG_VERSION` as repeating the delcaration in the 2nd ` FROM` scope is using the same value as previous declaration (cc @olblak for info)
- (non functional) Add more file presence test for installed binaries
- (functional) Bump Alpine Linux to 3.13
- (functional) Set the name of the default user to `infra` (instead of `user` which was a confusin value)