### PR TITLE
feat: add gh cli to allow images to be 'released'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,21 @@ RUN curl --silent --show-error --location --output /usr/local/bin/hadolint \
   && chmod a+x /usr/local/bin/hadolint \
   && hadolint -v
 
-LABEL io.jenkins-infra.tools="img,container-structure-test,git,make,hadolint"
+ARG GH_VERSION=1.8.1
+ARG GH_SHASUM_256="6df9b0214f352fe62b2998c2d1b9828f09c8e133307c855c20c1924134d3da25"
+RUN curl --silent --show-error --location --output /tmp/gh.tar.gz \
+   "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+  && sha256sum /tmp/gh.tar.gz | grep -q "${GH_SHASUM_256}" \
+  && tar xvfz /tmp/gh.tar.gz -C /tmp \
+  && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+  && chmod a+x /usr/local/bin/gh \
+  && gh --help
+
+LABEL io.jenkins-infra.tools="img,container-structure-test,git,make,hadolint,gh"
 LABEL io.jenkins-infra.tools.container-structure-test.version="${CST_VERSION}"
 LABEL io.jenkins-infra.tools.img.version="${IMG_VERSION}"
 LABEL io.jenkins-infra.tools.hadolint.version="${HADOLINT_VERSION}"
+LABEL io.jenkins-infra.tools.gh.version="${GH_VERSION}"
 
 ARG UID=1000
 ENV USER=infra

--- a/cst.yml
+++ b/cst.yml
@@ -11,13 +11,15 @@ metadataTest:
       value: "/run/infra/1000"
   labels:
     - key: io.jenkins-infra.tools
-      value: "img,container-structure-test,git,make,hadolint"
+      value: "img,container-structure-test,git,make,hadolint,gh"
     - key: io.jenkins-infra.tools.hadolint.version
       value: "1.19.0"
     - key: io.jenkins-infra.tools.container-structure-test.version
       value: "1.10.0"
     - key: io.jenkins-infra.tools.img.version
       value: "0.5.11"
+    - key: io.jenkins-infra.tools.gh.version
+      value: "1.8.1"
   entrypoint: []
   cmd: ["/bin/bash"]
   workdir: "/app"
@@ -33,6 +35,10 @@ fileExistenceTests:
     isExecutableBy: 'any'
   - name: 'img'
     path: '/usr/bin/img'
+    shouldExist: true
+    isExecutableBy: 'any'
+  - name: 'gh'
+    path: '/usr/local/bin/gh'
     shouldExist: true
     isExecutableBy: 'any'
   - name: 'img newuidmap'


### PR DESCRIPTION
When `useAtomicRelease` is set, we only get a tag, rather than a GitHub release, this has the side effect that releasenotes/changelogs are not available when updating images with `updatecli`.

We can use the gh cli to create a release e.g.

```
gh api -X PATCH -F draft=false -F name=$version -F tag_name=$version /repos/$GITHUB_REPOSITORY/releases/$release
``` 