### PR TITLE
chores: updatecli, naming and Jenkins pipeline fixes after 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # The official img's image is required to retrieve the img and new*idmap binaries
 ARG IMG_VERSION=0.5.11
-ARG JXRELEASEVERSION=2.5.1
+ARG JX_RELEASE_VERSION=2.5.1
 ARG JENKINS_AGENT_VERSION=4.11.2-2
 
-FROM ghcr.io/jenkins-x/jx-release-version:${JXRELEASEVERSION} AS jx-release-version
+FROM ghcr.io/jenkins-x/jx-release-version:${JX_RELEASE_VERSION} AS jx-release-version
 FROM r.j3ss.co/img:v${IMG_VERSION} AS img
 
 # Alpine is used by default for fast and ligthweight customization with a fixed minor to benefit of the latest patches
@@ -75,7 +75,7 @@ COPY --from=jx-release-version /usr/bin/jx-release-version /usr/bin/jx-release-v
 ## Repeating the ARGs from top level to allow them on this scope
 # Ref - https://docs.docker.com/engine/reference/builder/#scope
 ARG IMG_VERSION=0.5.11
-ARG JXRELEASEVERSION=2.5.1
+ARG JX_RELEASE_VERSION=2.5.1
 ARG JENKINS_AGENT_VERSION=4.11.2-2
 
 LABEL io.jenkins-infra.tools="img,container-structure-test,git,make,hadolint,gh,nodejs,npm,blobxfer,jx-release-version,jenkins-agent"
@@ -84,7 +84,7 @@ LABEL io.jenkins-infra.tools.img.version="${IMG_VERSION}"
 LABEL io.jenkins-infra.tools.blobxfer.version="${BLOBXFER_VERSION}"
 LABEL io.jenkins-infra.tools.hadolint.version="${HADOLINT_VERSION}"
 LABEL io.jenkins-infra.tools.gh.version="${GH_VERSION}"
-LABEL io.jenkins-infra.tools.jx-release-version.version="${JXRELEASEVERSION}"
+LABEL io.jenkins-infra.tools.jx-release-version.version="${JX_RELEASE_VERSION}"
 LABEL io.jenkins-infra.tools.jenkins-agent.version="${JENKINS_AGENT_VERSION}"
 
 ARG USER=jenkins

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,3 +1,1 @@
-buildDockerAndPublishImage('builder', [
-  builderImage: 'dduportal/jenkinsciinfra-builder:1.0.1',
-])
+parallelDockerUpdatecli([imageName: 'builder'])

--- a/updatecli/updatecli.d/blobxfer.yml
+++ b/updatecli/updatecli.d/blobxfer.yml
@@ -1,0 +1,76 @@
+---
+title: "Bump blobxfer version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest blobxfer version
+    spec:
+      owner: "Azure"
+      repository: "blobxfer"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is BLOBXFER_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BLOBXFER_VERSION"
+  testTestHarness:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.blobxfer.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[5].key"
+      value: io.jenkins-infra.tools.blobxfer.version
+
+targets:
+  updateTestVersion:
+    name: "Update the test harness"
+    sourceID: lastVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[5].value"
+    scmID: default
+  updateDockerfileVersion:
+    name: "Update the value of ARG BLOBXFER_VERSION in the Dockerfile"
+    sourceID: lastVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BLOBXFER_VERSION"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/cst.yml
+++ b/updatecli/updatecli.d/cst.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump cst version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   getCstVersion:
     kind: githubRelease
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgCstVersion:
     name: "Does the Dockerfile have an ARG instruction which key is CST_VERSION?"
@@ -31,24 +45,17 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[2].key"
       value: io.jenkins-infra.tools.container-structure-test.version
+
 targets:
-  updateCstCstVersion:
+  updateTestVersion:
     name: "Update the label io.jenkins-infra.tools.container-structure-test.version in the test harness"
     sourceID: getCstVersion
     kind: yaml
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[2].value"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
-  updateDockerfileArgCstVersion:
+    scmID: default
+  updateDockerfileVersion:
     name: "Update the value of ARG CST_VERSION in the Dockerfile"
     sourceID: getCstVersion
     kind: dockerfile
@@ -57,12 +64,15 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "CST_VERSION"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/cst.yml
+++ b/updatecli/updatecli.d/cst.yml
@@ -23,12 +23,10 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
-    transformers:
-      - trimPrefix: "v"
+        kind: semver
 
 conditions:
-  testDockerfileArgCstVersion:
+  testDockerfile:
     name: "Does the Dockerfile have an ARG instruction which key is CST_VERSION?"
     kind: dockerfile
     disablesourceinput: true
@@ -37,7 +35,7 @@ conditions:
       instruction:
         keyword: "ARG"
         matcher: "CST_VERSION"
-  testCstCstVersion:
+  testTestHarness:
     name: "Does the test harness checks for a label label io.jenkins-infra.tools.container-structure-test.version?"
     kind: yaml
     disablesourceinput: true

--- a/updatecli/updatecli.d/ghcli.yml
+++ b/updatecli/updatecli.d/ghcli.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump ghcli version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   getGhcliVersion:
     kind: githubRelease
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgGhcliVersion:
     name: "Does the Dockerfile have an ARG instruction which key is GH_VERSION?"
@@ -31,24 +45,17 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[4].key"
       value: io.jenkins-infra.tools.gh.version
+
 targets:
-  updateGhcliGhcliVersion:
+  updateTestVersion:
     name: "Update the label io.jenkins-infra.tools.gh.version in the test harness"
     sourceID: getGhcliVersion
     kind: yaml
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[4].value"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
-  updateDockerfileArgGhcliVersion:
+    scmID: default
+  updateDockerfileVersion:
     name: "Update the value of ARG GH_VERSION in the Dockerfile"
     sourceID: getGhcliVersion
     kind: dockerfile
@@ -57,12 +64,15 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "GH_VERSION"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/ghcli.yml
+++ b/updatecli/updatecli.d/ghcli.yml
@@ -23,9 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
-    transformers:
-      - trimPrefix: "v"
+        kind: semver
 
 conditions:
   testDockerfileArgGhcliVersion:

--- a/updatecli/updatecli.d/hadolint.yml
+++ b/updatecli/updatecli.d/hadolint.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump hadolint version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   getHadolintVersion:
     kind: githubRelease
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgHadolintVersion:
     name: "Does the Dockerfile have an ARG instruction which key is HADOLINT_VERSION?"
@@ -31,24 +45,17 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[1].key"
       value: io.jenkins-infra.tools.hadolint.version
+
 targets:
-  updateHadolintHadolintVersion:
+  updateTestVersion:
     name: "Update the label io.jenkins-infra.tools.hadolint.version in the test harness"
     sourceID: getHadolintVersion
     kind: yaml
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[1].value"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
-  updateDockerfileArgHadolintVersion:
+    scmID: default
+  updateDockerfileVersion:
     name: "Update the value of ARG HADOLINT_VERSION in the Dockerfile"
     sourceID: getHadolintVersion
     kind: dockerfile
@@ -57,12 +64,15 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "HADOLINT_VERSION"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/hadolint.yml
+++ b/updatecli/updatecli.d/hadolint.yml
@@ -23,9 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
-    transformers:
-      - trimPrefix: "v"
+        kind: semver
 
 conditions:
   testDockerfileArgHadolintVersion:

--- a/updatecli/updatecli.d/img.yml
+++ b/updatecli/updatecli.d/img.yml
@@ -23,9 +23,7 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionFilter:
-        kind: latest
-    transformers:
-      - trimPrefix: "v"
+        kind: semver
 
 conditions:
   testDockerfileArgImgVersion:

--- a/updatecli/updatecli.d/img.yml
+++ b/updatecli/updatecli.d/img.yml
@@ -1,5 +1,18 @@
 ---
 title: "Bump img version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
 sources:
   getImgVersion:
     kind: githubRelease
@@ -13,6 +26,7 @@ sources:
         kind: latest
     transformers:
       - trimPrefix: "v"
+
 conditions:
   testDockerfileArgImgVersion:
     name: "Does the Dockerfile have an ARG instruction which key is IMG_VERSION?"
@@ -31,24 +45,17 @@ conditions:
       file: "cst.yml"
       key: "metadataTest.labels[3].key"
       value: io.jenkins-infra.tools.img.version
+
 targets:
-  updateCstImgVersion:
+  updateTestVersion:
     name: "Update the label io.jenkins-infra.tools.img.version in the test harness"
     sourceID: getImgVersion
     kind: yaml
     spec:
       file: "cst.yml"
       key: "metadataTest.labels[3].value"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
-  updateDockerfileArgImgVersion:
+    scmID: default
+  updateDockerfileVersion:
     name: "Update the value of ARG IMG_VERSION in the Dockerfile"
     sourceID: getImgVersion
     kind: dockerfile
@@ -57,12 +64,15 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "IMG_VERSION"
-    scm:
-      github:
-        user: "{{ .github.user }}"
-        email: "{{ .github.email }}"
-        owner: "{{ .github.owner }}"
-        repository: "{{ .github.repository }}"
-        token: "{{ requiredEnv .github.token }}"
-        username: "{{ .github.username }}"
-        branch: "{{ .github.branch }}"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,0 +1,76 @@
+---
+title: "Bump jenkins-agent version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest jenkins-agent version
+    spec:
+      owner: "jenkinsci"
+      repository: "docker-inbound-agent"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+  testTestHarness:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.jenkins-agent.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[7].key"
+      value: io.jenkins-infra.tools.jenkins-agent.version
+
+targets:
+  updateTestVersion:
+    name: "Update the test harness"
+    sourceID: lastVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].value"
+    scmID: default
+  updateDockerfileVersion:
+    name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
+    sourceID: lastVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jx-release-version.yml
+++ b/updatecli/updatecli.d/jx-release-version.yml
@@ -1,0 +1,76 @@
+---
+title: "Bump jx-release-version version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubRelease
+    name: Get the latest jx-release-version version
+    spec:
+      owner: "jenkins-x-plugins"
+      repository: "jx-release-version"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: semver
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is JX_RELEASE_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JX_RELEASE_VERSION"
+  testTestHarness:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.jx-release-version.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].key"
+      value: io.jenkins-infra.tools.jx-release-version.version
+
+targets:
+  updateTestVersion:
+    name: "Update the test harness"
+    sourceID: lastVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].value"
+    scmID: default
+  updateDockerfileVersion:
+    name: "Update the value of ARG JX_RELEASE_VERSION in the Dockerfile"
+    sourceID: lastVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JX_RELEASE_VERSION"
+    scmID: default
+
+pullrequests:
+  default:
+    kind: github
+    scmID: default
+    targets:
+      - updateDockerfileVersion
+      - updateTestVersion
+    spec:
+      labels:
+        - dependencies


### PR DESCRIPTION
This PR introduces the following non-functionnal changes, forgottent during the 2.0 change of the image.

- Fix variable naming in `Dockerfile` (nitpick)
- Track missing new dependencies with updatecli (blobxfer, jenkins-agent version, jx-release-version)
- Update existing updatecli manifests to remove deprecation messages that appeared with 0.17.x of updatecli