### PR TITLE
chore(updatecli) fix the jenkins-agent manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -51,7 +51,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[6].value"
+      key: "metadataTest.labels[7].value"
     scmID: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"


### PR DESCRIPTION
This PR fixes the issues seen in #32 where the wrong field was updated by updatecli for the `jenkins-agent` version.

Closes #32 .