### PR TITLE
chore(release-drafter) Update GHA configuration

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,10 +3,11 @@ name: Release Drafter
 
 on:
   workflow_dispatch:
-  release:
   push:
-    branches:
-      - main
+  release:
+
+# Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases
+concurrency: "release-drafter"
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
- Ensure there is 1 and only 1 release "next" draft at a time
- Ensure that the "next" draft is kept alive and up to date once a release is done