### PR TITLE
Upgrade netlify deployer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN curl --silent --show-error --location --output /tmp/gh.tar.gz \
   && chmod a+x /usr/local/bin/gh \
   && gh --help
 
-ARG NETLIFY_DEPLOY=0.1.5
+ARG NETLIFY_DEPLOY=0.1.8
 RUN mkdir -p /tmp/netlify && \
   curl --silent --show-error --location --output /tmp/netlify.tar.gz \
   "https://github.com/halkeye/netlify-golang-deploy/releases/download/v${NETLIFY_DEPLOY}/netlify-golang-deploy_${NETLIFY_DEPLOY}_Linux_x86_64.tar.gz" \

--- a/cst.yml
+++ b/cst.yml
@@ -18,7 +18,7 @@ metadataTest:
         - key: io.jenkins-infra.tools.jenkins-inbound-agent.version
           value: "3107.v665000b_51092-4"
         - key: io.jenkins-infra.tools.netlify-deploy.version
-          value: "0.1.5"
+          value: "0.1.8"
         - key: io.jenkins-infra.tools.asdf.version
           value: "0.11.2"
         - key: io.jenkins-infra.tools.azure-cli.version


### PR DESCRIPTION
plugin site triggered some sort of https2 error

```
15:19:36  panic: Unable to upload file: Put "https://api.netlify.com/api/v1/deploys/640a68e2efe89306ffd0ef05/files/%2Fpage-data%2Fsrcclr-installer%2Fdependencies%2Fpage-data.json": http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
```

so latest version has a retry on it