### PR TITLE
fix(`blobxfer`): install `azure-cli` via deb package instead of `python3-dev`

### DIFF
--- a/cst.yml
+++ b/cst.yml
@@ -52,7 +52,7 @@ fileExistenceTests:
     shouldExist: true
     isExecutableBy: "any"
   - name: "Azure CLI"
-    path: "/usr/local/bin/az"
+    path: "/usr/bin/az"
     shouldExist: true
     isExecutableBy: "any"
   - name: "JQ"


### PR DESCRIPTION
The addition of `python3-dev`  to install `azure-cli` in #72 broke `blobxfer` as noted in https://github.com/jenkins-infra/docker-builder/pull/72#issuecomment-1467834361, and caused https://github.com/jenkins-infra/helpdesk/issues/3447

This PR installs `azure-cli` via its debian package instead.