### PR TITLE
Remove ruby 2.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,7 @@ ENV USER=${USER}
 ENV HOME=/home/"${USER}"
 
 # Install ASDF to install custom tools
-# Ruby 2 and NodeJS 18 is needed by the jenkins.io/plugins.jenkins.io websites
+# NodeJS 18 is needed by the jenkins.io/plugins.jenkins.io websites
 # Ruby 3 is needed by some of the jenkins-infra/infra-report
 ARG ASDF_VERSION=0.11.3
 RUN bash -c "git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch v${ASDF_VERSION} && \
@@ -105,9 +105,8 @@ RUN bash -c "git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch 
   printf 'yarn\njsonlint' > $HOME/.default-npm-packages && \
   . $HOME/.asdf/asdf.sh && \
   asdf plugin add ruby https://github.com/asdf-vm/asdf-ruby.git && \
-  asdf install ruby 2.7.7 && \
   asdf install ruby 3.2.2 && \
-  asdf global ruby 2.7.7 && \
+  asdf global ruby 3.2.2 && \
   asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
   asdf install nodejs 18.15.0 && \
   asdf global nodejs 18.15.0"


### PR DESCRIPTION
jenkins.io has been migrated to ruby 3, and the plugin site doesn't depend on ruby at all.
I looked for repositories using this image to build and could find no trace of ruby 2 dependencies.

If there are no private repositories using this image and depending on ruby 2, we can drop 2.x here.