### PR TITLE
breaking: switch to JDK17 for agent processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG JENKINS_INBOUND_AGENT_VERSION=3142.vcfca_0cd92128-1
 
-FROM jenkins/inbound-agent:${JENKINS_INBOUND_AGENT_VERSION}-jdk11
+FROM jenkins/inbound-agent:${JENKINS_INBOUND_AGENT_VERSION}-jdk17
 USER root
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 

--- a/cst.yml
+++ b/cst.yml
@@ -100,3 +100,9 @@ fileContentTests:
   - name: "Base OS is the expected distribution and versions"
     path: "/etc/os-release"
     expectedContents: ['PRETTY_NAME="Debian GNU/Linux 11 \(bullseye\)"']
+
+commandTests:
+  - name: "Check that `java` is present in the PATH and default to JDK17"
+    command: "java"
+    args: ["--version"]
+    expectedOutput: ["Temurin-17"]

--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -52,7 +52,7 @@ conditions:
     spec:
       image: "jenkins/inbound-agent"
       architecture: "amd64"
-      tag: '{{ source "lastVersion" }}-alpine-jdk11'
+      tag: '{{ source "lastVersion" }}-jdk17'
 
 
 


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072