### PR TITLE
Install node.js 20.8.0 and update node.js 18.17.0 to 18.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,8 +128,8 @@ RUN bash -c "git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch 
   asdf install ruby 3.2.2 && \
   asdf global ruby 3.2.2 && \
   asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
-  asdf install nodejs 18.17.0 && \
-  asdf global nodejs 18.17.0 && \
+  asdf install nodejs 18.18.0 && \
+  asdf global nodejs 18.18.0 && \
   asdf install nodejs 20.0.8"
 
 LABEL io.jenkins-infra.tools="azure-cli,git,make,gh,typos,nodejs,npm,blobxfer,jenkins-inbound-agent,netlify-deploy,asdf"

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN bash -c "git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch 
   asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
   asdf install nodejs 18.18.0 && \
   asdf global nodejs 18.18.0 && \
-  asdf install nodejs 20.0.8"
+  asdf install nodejs 20.8.0"
 
 LABEL io.jenkins-infra.tools="azure-cli,git,make,gh,typos,nodejs,npm,blobxfer,jenkins-inbound-agent,netlify-deploy,asdf"
 LABEL io.jenkins-infra.tools.blobxfer.version="${BLOBXFER_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,8 @@ RUN bash -c "git clone https://github.com/asdf-vm/asdf.git $HOME/.asdf --branch 
   asdf global ruby 3.2.2 && \
   asdf plugin add nodejs https://github.com/asdf-vm/asdf-nodejs.git && \
   asdf install nodejs 18.17.0 && \
-  asdf global nodejs 18.17.0"
+  asdf global nodejs 18.17.0 && \
+  asdf install nodejs 20.0.8"
 
 LABEL io.jenkins-infra.tools="azure-cli,git,make,gh,typos,nodejs,npm,blobxfer,jenkins-inbound-agent,netlify-deploy,asdf"
 LABEL io.jenkins-infra.tools.blobxfer.version="${BLOBXFER_VERSION}"


### PR DESCRIPTION
[Within the next few days](https://github.com/nodejs/Release), Node.js 18.x's status changes from being the current LTS to maintenance-only, while 20.x becomes the next LTS line.

To facilitate tooling updates, I'd like to install Node.js 20 alongside 18 for the moment, allowing repositories to move to 20 without immediately losing access to releases for 20 only, if they aren't ready yet.

Additionally, the PR updates Node.js 18 (hopefully for the last time :P)