### PR TITLE
chore(updatecli): use `agent` repo as source reference in the `inbound-agent` manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -16,10 +16,10 @@ scms:
 sources:
   lastVersion:
     kind: githubrelease
-    name: Get the latest jenkins-inbound-agent version
+    name: Get the latest version
     spec:
       owner: "jenkinsci"
-      repository: "docker-inbound-agent"
+      repository: "docker-agent"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:


### PR DESCRIPTION
This PR uses the agent repo as source reference instead of the inbound-agent repo, as this one has been integrated into the agent one.

Similar to:
- https://github.com/jenkins-infra/docker-packaging/pull/95

Follow-up of:
- https://github.com/jenkinsci/docker-agent/issues/570

Ref:
- https://github.com/jenkinsci/docker-agent/issues/569#issuecomment-1890230875