### PR TITLE
chore: add `azcopy` updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/azcopy.yml
+++ b/updatecli/updatecli.d/azcopy.yml
@@ -1,0 +1,72 @@
+---
+name: Bump `azcopy` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: shell
+    name: Get the latest `azcopy` (full) version
+    spec:
+      command: bash -c 'basename "$(dirname "$(curl https://aka.ms/downloadazcopy-v10-linux --write-out "%{redirect_url}" --output /dev/null --silent --fail --show-error)" )"'
+    transformers:
+      - trimprefix: 'release-'
+
+conditions:
+  testDockerfileArgAzCliVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is AZCOPY_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AZCOPY_VERSION"
+  testCstAzCliVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.azcopy.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].key"
+      value: io.jenkins-infra.tools.azcopy.version
+
+targets:
+  updateCstVersion:
+    name: "Update the label io.jenkins-infra.tools.azcopy.version in the test harness"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[6].value"
+    scmid: default
+  updateDockerfileArgVersion:
+    name: "Update the value of ARG AZCOPY_VERSION in the Dockerfile"
+    sourceid: lastReleaseVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AZCOPY_VERSION"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump azcopy version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - azcopy


### PR DESCRIPTION
This PR adds an updatecli manifest to track azcopy versions.

Follow-up of:
- #182

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809
- https://github.com/jenkins-infra/helpdesk/issues/3414