### PR TITLE
chore: fix `azure-cli` updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/asdf.yml
+++ b/updatecli/updatecli.d/asdf.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[5].key"
+      key: "$.metadataTest.labels[5].key"
       value: io.jenkins-infra.tools.asdf.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[5].value"
+      key: "$.metadataTest.labels[5].value"
     scmid: default
   updateDockerfileArgVersion:
     name: "Update the value of ARG ASDF_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/azure-cli.yml
+++ b/updatecli/updatecli.d/azure-cli.yml
@@ -45,7 +45,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[6].key"
+      key: "metadataTest.labels[7].key"
       value: io.jenkins-infra.tools.azure-cli.version
 
 targets:
@@ -55,7 +55,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[6].value"
+      key: "metadataTest.labels[7].value"
     scmid: default
   updateDockerfileArgVersion:
     name: "Update the value of ARG AZ_CLI_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/azure-cli.yml
+++ b/updatecli/updatecli.d/azure-cli.yml
@@ -45,7 +45,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[7].key"
+      key: "$.metadataTest.labels[7].key"
       value: io.jenkins-infra.tools.azure-cli.version
 
 targets:
@@ -55,7 +55,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[7].value"
+      key: "$.metadataTest.labels[7].value"
     scmid: default
   updateDockerfileArgVersion:
     name: "Update the value of ARG AZ_CLI_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/blobxfer.yml
+++ b/updatecli/updatecli.d/blobxfer.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[2].key"
+      key: "$.metadataTest.labels[2].key"
       value: io.jenkins-infra.tools.blobxfer.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[2].value"
+      key: "$.metadataTest.labels[2].value"
     scmid: default
   updateDockerfileVersion:
     name: "Update the value of ARG BLOBXFER_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/ghcli.yml
+++ b/updatecli/updatecli.d/ghcli.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[1].key"
+      key: "$.metadataTest.labels[1].key"
       value: io.jenkins-infra.tools.gh.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[1].value"
+      key: "$.metadataTest.labels[1].value"
     scmid: default
   updateDockerfileVersion:
     name: "Update the value of ARG GH_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[3].key"
+      key: "$.metadataTest.labels[3].key"
       value: io.jenkins-infra.tools.jenkins-inbound-agent.version
   checkDockerImagePublished:
     name: "Is latest dockerfile docker-inbound-agent image published?"
@@ -63,7 +63,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[3].value"
+      key: "$.metadataTest.labels[3].value"
     scmid: default
   updateDockerfileVersion:
     name: "Update the value of ARG JENKINS_INBOUND_AGENT_VERSION in the Dockerfile"

--- a/updatecli/updatecli.d/netlify-deploy.yml
+++ b/updatecli/updatecli.d/netlify-deploy.yml
@@ -43,7 +43,7 @@ conditions:
     disablesourceinput: true
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[4].key"
+      key: "$.metadataTest.labels[4].key"
       value: io.jenkins-infra.tools.netlify-deploy.version
 
 targets:
@@ -53,7 +53,7 @@ targets:
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[4].value"
+      key: "$.metadataTest.labels[4].value"
     scmid: default
   updateDockerfileVersion:
     name: "Update the value of ARG NETLIFY_DEPLOY in the Dockerfile"


### PR DESCRIPTION
This PR fixes azure-cli updatecli manifest, and resolve the deprecation warning in all manifests due to the missing `$.` prefix for the YAML keys.

Fixup of:
- #182 

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809