### PR TITLE
chore(azcopy) switch to (apt) package version

### DIFF
--- a/cst.yml
+++ b/cst.yml
@@ -56,7 +56,7 @@ fileExistenceTests:
     shouldExist: true
     isExecutableBy: "any"
   - name: "azcopy"
-    path: "/usr/local/bin/azcopy"
+    path: "/usr/bin/azcopy"
     shouldExist: true
     isExecutableBy: "any"
   - name: "Azure CLI"

--- a/cst.yml
+++ b/cst.yml
@@ -20,7 +20,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.asdf.version
       value: 0.15.0
     - key: io.jenkins-infra.tools.azcopy.version
-      value: 10.27.1-20241113
+      value: 10.27.1
     - key: io.jenkins-infra.tools.azure-cli.version
       value: 2.67.0
     - key: io.jenkins-infra.tools.typos.version

--- a/updatecli/updatecli.d/azcopy.yml
+++ b/updatecli/updatecli.d/azcopy.yml
@@ -15,12 +15,13 @@ scms:
 
 sources:
   lastReleaseVersion:
-    kind: shell
-    name: Get the latest `azcopy` (full) version
+    kind: githubrelease
+    name: Get the latest `azcopy` version
     spec:
-      command: bash -c 'basename "$(dirname "$(curl https://aka.ms/downloadazcopy-v10-linux --write-out "%{redirect_url}" --output /dev/null --silent --fail --show-error)" )"'
-    transformers:
-      - trimprefix: 'release-'
+      owner: Azure
+      repository: azure-storage-azcopy
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
 
 conditions:
   testDockerfileArgAzCliVersion:


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4471

This PR changes the installation method for `azcopy` from "Download Binary" to "Use APT Package".

It follows instructions from https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10?tabs=dnf#install-azcopy-on-linux-by-using-a-package-manager.

Note: `updatecli` manifest updated to track the version from https://github.com/Azure/azure-storage-azcopy/releases. The check will mention "2 changes" even though they have been applied, because it targets the `main` branch