### PR TITLE
chore(updatecli): remove regex on source to get the correct latest

### DIFF
--- a/updatecli/updatecli.d/jenkins-inbound-agent.yml
+++ b/updatecli/updatecli.d/jenkins-inbound-agent.yml
@@ -22,10 +22,6 @@ sources:
       repository: "docker-agent"
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
-      versionfilter:
-        kind: regex
-        ## not the JDK8 version - regex from https://stackoverflow.com/questions/16398471/regex-for-string-not-ending-with-given-suffix/16398502#16398502
-        pattern: '.*[^-][^j][^d][^k][^8]$'
 
 conditions:
   testDockerfile:


### PR DESCRIPTION
during https://github.com/jenkins-infra/helpdesk/issues/4510#issue-2813191991 
I realized that the updatecli was not generating the PR to update that dockerfile.