### PR TITLE
chore(updatecli): add a manifest to track crate-ci/typos

### DIFF
--- a/updatecli/updatecli.d/typos.yml
+++ b/updatecli/updatecli.d/typos.yml
@@ -1,0 +1,75 @@
+---
+name: Bump `typos` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `typos` version
+    spec:
+      owner: crate-ci
+      repository: typos
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: 'v'
+
+conditions:
+  testDockerfileArgTyposVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is TYPOS_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "TYPOS_VERSION"
+  testCstTyposVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.typos.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "$.metadataTest.labels[7].key"
+      value: io.jenkins-infra.tools.typos.version
+
+targets:
+  updateCstVersion:
+    name: "Update the label io.jenkins-infra.tools.typos.version in the test harness"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "$.metadataTest.labels[7].value"
+    scmid: default
+  updateDockerfileArgVersion:
+    name: "Update the value of ARG TYPOS_VERSION in the Dockerfile"
+    sourceid: lastReleaseVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "TYPOS_VERSION"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump typos version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - typos


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4659

track crateci/typos releases